### PR TITLE
Added configuration settings for operation

### DIFF
--- a/src/rabbithub.erl
+++ b/src/rabbithub.erl
@@ -208,15 +208,16 @@ deliver_via_post(#rabbithub_subscription{callback = Callback},
 
            URL = Callback ++ Topic,
 
+		   ContentType = case ContentTypeBin of
+							undefined -> "application/octet-stream";
+							_ -> binary_to_list(ContentTypeBin)
+						 end,
+
 		   Payload = {URL, 
 					 [{"Content-length", integer_to_list(size(PayloadBin))},
-					  {"Content-type", case ContentTypeBin of
-										  undefined -> "application/octet-stream";
-										  _ -> binary_to_list(ContentTypeBin)
-							end},
 					  {"X-AMQP-Routing-Key", binary_to_list(RoutingKeyBin)} | ExtraHeaders], 
-                      [], PayloadBin},
-
+                      ContentType, PayloadBin},
+						 
 		   % Log the request if the environment variable has been set - default
 		   % is not to log the request
 		   case application:get_env(rabbithub, log_http_post_request) of

--- a/src/rabbithub_consumer.erl
+++ b/src/rabbithub_consumer.erl
@@ -14,7 +14,7 @@ init([Lease = #rabbithub_lease{subscription = Subscription}]) ->
     process_flag(trap_exit, true),
     case rabbithub_subscription:register_subscription_pid(Lease, self(), ?MODULE) of
         ok ->
-            really_init(Subscription);
+           really_init(Subscription);
         expired ->
             {stop, normal};
         duplicate ->
@@ -36,9 +36,9 @@ really_init(Subscription = #rabbithub_subscription{resource = Resource}) ->
                         q_monitor_ref = MonRef,
                         consumer_tag = ConsumerTag}};
         {error, not_found} ->
-            ok = rabbithub:error_and_unsub(Subscription,
-                                           {rabbithub_consumer, queue_not_found, Subscription}),
-            {stop, not_found}
+			ok = rabbithub:error_and_unsub(Subscription,
+										   {rabbithub_consumer, queue_not_found, Subscription}),
+			{stop, not_found}
     end.
 
 handle_call(Request, _From, State) ->
@@ -58,7 +58,7 @@ handle_cast({deliver, _ConsumerTag, AckRequired,
                 false ->
                     ok
             end;
-        {error, Reason} ->
+        {error, Reason, Content} ->
             case is_integer(Reason) of 
                 true ->
                     %% If requeue_on_http_post_error is set to false then messages associated with
@@ -83,12 +83,12 @@ handle_cast({deliver, _ConsumerTag, AckRequired,
                            end;
                        _ ->
                            ok
-                       end;
+                    end;
                 false ->
                     ok
             end,
             ok = rabbithub:error_and_unsub(Subscription,
-                                           {rabbithub_consumer, http_post_failure, Reason})
+                                           {rabbithub_consumer, http_post_failure, Reason, Content})
     end,
     {noreply, State};
 handle_cast(shutdown, State) ->

--- a/src/rabbithub_pseudo_queue.erl
+++ b/src/rabbithub_pseudo_queue.erl
@@ -52,9 +52,9 @@ deliver(BasicMessage, Subscription, State) ->
     case rabbithub:deliver_via_post(Subscription, BasicMessage, []) of
         {ok, _} ->
             ok;
-        {error, Reason} ->
+        {error, Reason, Content} ->
             ok = rabbithub:error_and_unsub(Subscription,
-                                           {rabbithub_pseudo_queue, http_post_failure, Reason})
+                                           {rabbithub_pseudo_queue, http_post_failure, Reason, Content})
     end,
     {noreply, State}.
 


### PR DESCRIPTION
- Added configuration setting and code to suppress the hub.topic part of the callback URL if desired
- Added configuration setting and code to log the POST request bodies if desired
- Added configuration setting and code to stop unsubscribe on post error if desired
- Added to the log of the post error to include the complete response
- Fixed code that did not report Content-Type properly
